### PR TITLE
Fixed bug that results in "Error in substr(y, 4, 5): object 'y' not found" when using utm projection

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,6 +1,0 @@
-library(devtools)
-ck <- function(run_dont_test=FALSE) {
-	unlink("output")
-	dir.create("output", showWarnings = FALSE)
-	check("pkg", check_dir="output", run_dont_test = run_dont_test)
-}

--- a/pkg/R/get_proj4_code.R
+++ b/pkg/R/get_proj4_code.R
@@ -52,7 +52,7 @@ get_proj4 <- function(x, as.CRS=FALSE) {
 			y <- ycheck[[2]]
 			check_args <- FALSE
 		} else if (substr(x, 1, 3)=="utm") {
-			y <- paste("+proj=utm +zone=", substr(y, 4, 5), ifelse(substr(y, 6, 6)=="s", " +south", ""), " +ellps=WGS84 +datum=WGS84 +units=m +no_defs +towgs84=0,0,0", sep="")
+			y <- paste("+proj=utm +zone=", substr(x, 4, 5), ifelse(substr(x, 6, 6)=="s", " +south", ""), " +ellps=WGS84 +datum=WGS84 +units=m +no_defs +towgs84=0,0,0", sep="")
 			check_args <- TRUE
 		} else {
 			y <- x


### PR DESCRIPTION
When generating maps using a UTM projection, `print_tmap` returns the following error:

```Error in substr(y, 4, 5): object 'y' not found```

I traced the error to line 55 in `get_proj4_code.R`.  In the right-hand-side of that assignment, the code refers to variable `y` which has not yet been defined in the function.  I believe that should be variable `x`.  This fixed the error for me.

Hope this helps.  Really like the package!