### PR TITLE
minor tmap_animation update suggestion

### DIFF
--- a/R/tmap_animation.R
+++ b/R/tmap_animation.R
@@ -19,7 +19,7 @@ tmap_animation <- function(tm, filename="animation.gif", width=NA, height=NA, de
     	} else {
         	syscall <- shell
     	}
-	checkIM <- syscall("convert -version")
+	checkIM <- syscall("magick convert -version")
 	if (checkIM!=0) stop("Could not find ImageMagick. Make sure it is installed and included in the systems PATH")
 
 	# create plots
@@ -28,7 +28,7 @@ tmap_animation <- function(tm, filename="animation.gif", width=NA, height=NA, de
 	tmap_save(tm, filename = paste(d, "plot%03d.png", sep="/"), width=width, height=height)
 
 	# convert pngs to one gif using ImageMagick
-	output <- syscall(paste("convert -delay ", delay, " ", d, "/*.png \"", filename, "\"", sep=""))
+	output <- syscall(paste("magick convert -delay ", delay, " ", d, "/*.png \"", filename, "\"", sep=""))
 	
 	# cleaning up plots and temporary variables
 	unlink(d, recursive = TRUE)


### PR DESCRIPTION
Hey Martijn,
I am just playing around with `tmap_animation()`. There is a minor probably Windows-only issue related to: 
https://stackoverflow.com/questions/40096966/r-tmap-animation-tmap-imagemagick
When installing ImageMagick, one has to check a box "install legacy files (e.g., convert.exe)". Not doing so results in an error message since there seems to be another convert command under Windows. This this is not well-documented, I think it would be more user-friendly to be more specific in the code of `tmap_animation()` in the sense to make clear that the convert command of ImageMagick should be used (see minor file change).
As a side note, the first example of `tmap_animation()` is not working, since there is no object called `NLD_prov`.