### PR TITLE
preparation for new 'grid' unit implementation

### DIFF
--- a/R/grob_mod.R
+++ b/R/grob_mod.R
@@ -13,6 +13,6 @@ grob_mod <- function(grb, x.a=0, x.b=1, y.a=0, y.b=1) {
 }
 
 unit_mod <- function(unt, a=0, b=1) {
-	cls <- attr(unt, "unit")
-	unit(as.numeric(unt)*b + a, cls)
+    units <- unitType(unt)
+    unit(as.numeric(unt)*b + a, units)
 }

--- a/R/grob_mod.R
+++ b/R/grob_mod.R
@@ -13,6 +13,12 @@ grob_mod <- function(grb, x.a=0, x.b=1, y.a=0, y.b=1) {
 }
 
 unit_mod <- function(unt, a=0, b=1) {
-    units <- unitType(unt)
-    unit(as.numeric(unt)*b + a, units)
+    if (getRversion() >= "4.0.0") {
+        unitType <- get("unitType", envir=asNamespace("grid"))
+        units <- unitType(unt)
+        unit(as.numeric(unt)*b + a, units)
+    } else {
+        cls <- attr(unt, "unit")
+        unit(as.numeric(unt)*b + a, cls)
+    }
 }


### PR DESCRIPTION
Hi

Thomas Lin Pedersen and I are working on a faster implementation of units in 'grid' (thomasp85/grid#14).
These changes break `tmap:::unit_mod`.
This PR suggests a fix that will still work on current R releases (and R-devel), but will also accommodate the new 'grid' units.
Would you consider incorporating this in 'tmap' and at some point getting this change onto CRAN?
We are trying to eliminate as many CRAN problems as possible before we commit to R-devel.

Paul