### PR TITLE
Added maxWidth option to tm_credits.

### DIFF
--- a/R/plot_attributes.R
+++ b/R/plot_attributes.R
@@ -111,7 +111,7 @@ plot_logo <- function(gt, just, id) {
 	
 }
 
-plot_cred <- function(gt, just, id) {
+plot_cred <- function(gt, just, id, maxWidth) {
 	lineHeight <- convertHeight(unit(1, "lines"), "npc", valueOnly=TRUE)
 	
 	my <- lineHeight / 2
@@ -123,7 +123,7 @@ plot_cred <- function(gt, just, id) {
 	
 	size <- min((1-2*mx) / text_width_npc(txt, space=FALSE), gt$credits.size[id])
 	
-	width <- (text_width_npc(txt, space=FALSE)+1*mx) * size
+	width <- ifelse(maxWidth, 1, (text_width_npc(txt, space=FALSE)+1*mx) * size)
 	#height <- lineHeight * (nlines) * size
 	
 	x <- just - just*width

--- a/R/plot_meta.R
+++ b/R/plot_meta.R
@@ -289,6 +289,7 @@ plot_meta <- function(gt, x, legend_pos, bb, metaX, metaY, frameX, frameY, use_f
 				 just1=sapply(gt$credits.just, "[", 1, USE.NAMES=FALSE),
 				 just2=sapply(gt$credits.just, "[", 2, USE.NAMES=FALSE),
 				 sortid=gt$credits.id,
+				 maxWidth=gt$credits.maxWidth,
 				 stringsAsFactors = FALSE) else NULL,
 			if (gt$logo.show) data.frame(type="logo",
 				height=mapply(function(lh, m) {
@@ -466,7 +467,7 @@ plot_meta <- function(gt, x, legend_pos, bb, metaX, metaY, frameX, frameY, use_f
 				pushViewport(vpi)
 				
 				if (e$type=="credits") {
-					grb <- plot_cred(gt, just=elem.just[1], id=e$cred.id)
+					grb <- plot_cred(gt, just=elem.just[1], id=e$cred.id, maxWidth=e$maxWidth)
 				} else if (e$type=="logo") {
 					grb <- plot_logo(gt, just=elem.just[1], id=e$logo.id)
 				} else if (e$type=="scale_bar") {

--- a/R/tm_misc_elements.R
+++ b/R/tm_misc_elements.R
@@ -162,9 +162,10 @@ tm_graticules <- function(x=NA,
 #' @param bg.color background color for the text
 #' @param bg.alpha Transparency number between 0 (totally transparent) and 1 (not transparent). By default, the alpha value of the \code{bg.color} is used (normally 1).
 #' @param fontface font face of the text. By default, determined by the fontface argument of \code{\link{tm_layout}}.
-#' @param fontfamily font family of the text. By default, determined by the fontfamily argument of \code{\link{tm_layout}}.
+#' @param fontfamily font family of the text. By default, determined by the font family argument of \code{\link{tm_layout}}.
 #' @param position position of the text. Vector of two values, specifying the x and y coordinates. Either this vector contains "left", "LEFT", "center", "right", or "RIGHT" for the first value and "top", "TOP", "center", "bottom", or "BOTTOM" for the second value, or this vector contains two numeric values between 0 and 1 that specifies the x and y value of the center of the text. The uppercase values correspond to the position without margins (so tighter to the frame). The default value is controlled by the argument \code{"attr.position"} of \code{\link{tm_layout}}.
-#' @param just Justification of the attribute relative to the point coordinates.  The first value specifies horizontal and the second value vertical justification. Possible values are: \code{"left"} , \code{"right"}, \code{"center"}, \code{"bottom"}, and \code{"top"}. Numeric values of 0 specify left/bottom alignment and 1 right/top alignment. This option is only used, if \code{position} is specified by numeric coordinates. The default value is controlled by the argument \code{"attr.just"} of \code{\link{tm_layout}}.
+#' @param just Justification of the attribute relative to the point coordinates. The first value specifies horizontal and the second value vertical justification. Possible values are: \code{"left"} , \code{"right"}, \code{"center"}, \code{"bottom"}, and \code{"top"}. Numeric values of 0 specify left/bottom alignment and 1 right/top alignment. This option is only used, if \code{position} is specified by numeric coordinates. The default value is controlled by the argument \code{"attr.just"} of \code{\link{tm_layout}}.
+#' @param maxWidth Should the credits span the whole width of the map.
 #' @export
 #' @seealso \code{\link{tm_xlab}}
 #' @example ./examples/tm_credits.R
@@ -177,7 +178,8 @@ tm_credits <- function(text,
 					   bg.alpha=NA,
 					   fontface=NA, fontfamily=NA,
 					   position=NA,
-					   just=NA) {
+					   just=NA,
+					   maxWidth=F) {
 	g <- list(tm_credits=as.list(environment()))
 	names(g$tm_credits) <- paste("credits", names(g$tm_credits), sep=".")
 	class(g) <- "tmap"


### PR DESCRIPTION
While creating several maps for my employer, I needed the feature to have full width credits on the bottom of the map, no matter the actual size of the credits text. For corporate designs that might be useful.