### PR TITLE
fixes order of checks in tmap_save

### DIFF
--- a/R/tmap_save.R
+++ b/R/tmap_save.R
@@ -318,15 +318,15 @@ plot_device = function(device, ext, filename, dpi, units_target){
 				units = units_target
 			)
 	)
-	if (!device %in% names(devices)) {
-		stop('"', device, '"', " graphic device does not exist", call. = FALSE)
-	}
 	if (is.null(device)) {
 		dev <- devices[[ext]]
 		if (is.null(dev)) {
 			stop("'", dev, "'", " graphic device does not exist", call. = FALSE)
 		}
 		return(dev)
+	}
+	if (!device %in% names(devices)) {
+		stop('"', device, '"', " graphic device does not exist", call. = FALSE)
 	}
 }
 


### PR DESCRIPTION
fixes the following issue:

``` r
library(tmap)
library(sf)
library(spData)
tm = tm_shape(world) +
    tm_polygons()
tmap_save(tm)
#> Error in if (!device %in% names(devices)) {: argument is of length zero
```

<sup>Created on 2021-08-23 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>